### PR TITLE
fix for special case of hover area

### DIFF
--- a/client/desktop/ChatView/ConversationWindow/ChatBubbleHover.qml
+++ b/client/desktop/ChatView/ConversationWindow/ChatBubbleHover.qml
@@ -38,15 +38,16 @@ MouseArea {
 
         anchors {
             right: parent.right
+            rightMargin: (download && reply) ? CmnCfg.defaultMargin : 0
             top: parent.top
             topMargin: CmnCfg.smallMargin
         }
 
-        Row {
+        Grid {
             id: buttonRow
-            spacing: CmnCfg.defaultMargin
-            rightPadding: CmnCfg.smallMargin
-
+            rows: 2
+            columns: (download && reply) ? 2 : 4
+            spacing: CmnCfg.smallMargin
             Imports.IconButton {
                 id: replyButton
                 anchors.margins: CmnCfg.defaultMargin


### PR DESCRIPTION
This is a micro branch showcasing a potential fix for the final unmarked checkbox in #84. in the special case that overlap occurs, it simply turns the buttons into a 2x2 grid. screens attached

<img width="600" alt="Screen Shot 2020-01-05 at 3 36 08 AM" src="https://user-images.githubusercontent.com/29527663/71779641-9326fa00-2f6c-11ea-8155-5549b7397a88.png">


 