### PR TITLE
Add synchronization to mac notifications

### DIFF
--- a/libherald/src/herald/notif_handler.rs
+++ b/libherald/src/herald/notif_handler.rs
@@ -18,6 +18,7 @@ impl NotifHandler {
 
         match notif {
             NewMsg(msg) => {
+                crate::toasts::new_msg_toast(msg.as_ref());
                 let cid = msg.conversation;
                 err!(content_push(cid, MsgUpdate::NewMsg(msg)));
             }

--- a/libherald/src/messages/mod.rs
+++ b/libherald/src/messages/mod.rs
@@ -2,7 +2,6 @@ use crate::{
     err,
     interface::{MessagesEmitter as Emitter, MessagesList as List},
     none,
-    toasts::new_msg_toast,
 };
 use herald_common::UserId;
 use heraldcore::{
@@ -50,17 +49,18 @@ impl Messages {
                 variant: ConvItemUpdateVariant::NewActivity,
             })
         };
+
         match update {
             MsgUpdate::NewMsg(new) => {
-                new_msg_toast(new.as_ref());
-
                 self.container
                     .insert_helper(*new, emit, model, search, cid, push);
             }
+
             MsgUpdate::BuilderMsg(msg) => {
                 self.container
                     .insert_helper(*msg, emit, model, search, cid, push);
             }
+
             MsgUpdate::Receipt {
                 msg_id,
                 recipient,
@@ -83,21 +83,25 @@ impl Messages {
                 self.container
                     .handle_reaction(msg_id, reactionary, content, remove, model);
             }
+
             MsgUpdate::StoreDone(mid, meta) => {
                 let model = &mut self.model;
                 let emit = &mut self.emit;
 
                 none!(&self.container.handle_store_done(mid, meta, emit, model));
             }
+
             MsgUpdate::SendDone(mid) => {
                 let model = &mut self.model;
 
                 none!(&self.container.handle_send_done(mid, model));
             }
+
             MsgUpdate::ExpiredMessages(mids) => {
                 self.container
                     .handle_expiration(mids, emit, model, search, &mut self.builder)
             }
+
             MsgUpdate::Container(container) => {
                 if container.is_empty() {
                     return;
@@ -119,12 +123,14 @@ impl Messages {
 pub(crate) enum MsgUpdate {
     /// A new message
     NewMsg(Box<heraldcore::message::Message>),
+
     /// A message has been acknowledged
     Receipt {
         msg_id: MsgId,
         recipient: UserId,
         status: MessageReceiptStatus,
     },
+
     /// A reaction has been added or removed
     Reaction {
         msg_id: MsgId,
@@ -132,14 +138,19 @@ pub(crate) enum MsgUpdate {
         content: heraldcore::message::ReactContent,
         remove: bool,
     },
+
     /// A rendered message from the `MessageBuilder`
     BuilderMsg(Box<heraldcore::message::Message>),
+
     /// An outbound message has been saved
     StoreDone(MsgId, herald_attachments::AttachmentMeta),
+
     /// There are expired messages that need to be pruned
     ExpiredMessages(Vec<MsgId>),
+
     /// The container contents, sent when the conversation id is first set.
     Container(Box<Container>),
+
     /// An outbound message has arrived at the server
     SendDone(MsgId),
 }

--- a/libherald/src/toasts/mod.rs
+++ b/libherald/src/toasts/mod.rs
@@ -46,13 +46,13 @@ mod imp {
 
     static IS_SET: OnceCell<bool> = OnceCell::new();
 
-    fn setup() {
-        IS_SET
+    fn setup() -> bool {
+        *IS_SET
             .get_or_try_init(|| {
                 let bundle = get_bundle_identifier_or_default(super::DESKTOP_APP_NAME);
                 drop(set_application(&bundle));
             })
-            .unwrap_or(false)
+            .unwrap_or(&false)
     }
 
     pub fn new_msg_toast(msg: &Message) {

--- a/libherald/src/toasts/mod.rs
+++ b/libherald/src/toasts/mod.rs
@@ -50,7 +50,8 @@ mod imp {
         *IS_SET
             .get_or_try_init(|| {
                 let bundle = get_bundle_identifier_or_default(super::DESKTOP_APP_NAME);
-                set_application(&bundle)
+                set_application(&bundle)?;
+                Ok(true)
             })
             .unwrap_or(&false)
     }

--- a/libherald/src/toasts/mod.rs
+++ b/libherald/src/toasts/mod.rs
@@ -50,8 +50,8 @@ mod imp {
         *IS_SET
             .get_or_try_init(|| {
                 let bundle = get_bundle_identifier_or_default(super::DESKTOP_APP_NAME);
-                set_application(&bundle)?;
-                Ok(true)
+                set_application(&bundle).map_err(|_| ())?;
+                Ok::<bool, ()>(true)
             })
             .unwrap_or(&false)
     }

--- a/libherald/src/toasts/mod.rs
+++ b/libherald/src/toasts/mod.rs
@@ -50,7 +50,7 @@ mod imp {
         *IS_SET
             .get_or_try_init(|| {
                 let bundle = get_bundle_identifier_or_default(super::DESKTOP_APP_NAME);
-                drop(set_application(&bundle));
+                set_application(&bundle)
             })
             .unwrap_or(&false)
     }


### PR DESCRIPTION
Previously, the push notifications on macOS were using an unsafe function from a library that was erroneously marked as safe. This PR adds synchronization logic.